### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme-checker.yaml
+++ b/.github/workflows/readme-checker.yaml
@@ -1,4 +1,6 @@
 name: markdown-lint
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/vs-snippets/security/code-scanning/1](https://github.com/gvatsal60/vs-snippets/security/code-scanning/1)

To fix the problem, we need to explicitly define the permissions for the workflow or job. Since the workflow performs read-only operations (linting markdown files), the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to complete the task.

The fix involves adding a `permissions` block at the root of the workflow file, which will apply to all jobs in the workflow. Alternatively, the `permissions` block can be added to the specific job (`lint`) if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
